### PR TITLE
ci: Use go/code-sanity@v1

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Go code sanity check
-        uses: canonical/desktop-engineering/gh-actions/go/code-sanity@main
+        uses: canonical/desktop-engineering/gh-actions/go/code-sanity@v1
         with:
           golangci-lint-configfile: ".golangci.yaml"
           tools-directory: "tools"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/go-i18n
 
-go 1.20
+go 1.21
 
 require (
 	github.com/leonelquinteros/gotext v1.5.3-0.20230829162019-37f474cfb069


### PR DESCRIPTION
We're about to merge a breaking change in the `go/code-sanity` GitHub Action ([use of golangci-lint v2 instead of v1](https://github.com/canonical/desktop-engineering/pull/75)), so to avoid breaking the CI, we need to switch to `go/code-sanity@v1` instead of `go/code-sanity@main`.

Once the change has been merged, I will prepare a follow-up PR to migrate the `.golangci.yaml` to the v2 format and use `go/code-sanity@v2`.

UDENG-7801