### PR TITLE
Bump Go version to 1.23.10

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,7 +61,3 @@ linters-settings:
   # Never have naked return ever
   nakedret:
     max-func-lines: 1
-  staticcheck:
-    # Should be better for it to be autodetected
-    # https://github.com/golangci/golangci-lint/issues/2234
-    go: "1.20"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/go-i18n
 
-go 1.20
+go 1.23.10
 
 require (
 	github.com/leonelquinteros/gotext v1.5.3-0.20230829162019-37f474cfb069


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in 1.20:

```
Vulnerability #1: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: os@go1.21.13
    Fixed in: os@go1.23.10
    Platforms: windows
    Example traces found:
Error:       #1: cmd/update-po/main.go:80:21: update.i18nToPot calls os.Create
[...]

Vulnerability #2: GO-2025-3447
    Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
  More info: https://pkg.go.dev/vuln/GO-2025-3447
  Standard library
    Found in: crypto/internal/nistec@go1.21.13
    Fixed in: crypto/internal/nistec@go1.22.12
    Platforms: ppc64le
    Example traces found:
Error:       #1: i18n_test.go:22:24: i18n_test.ExampleInitI18nDomain_embeddedFiles calls gotext.Get, which eventually calls nistec.P256Point.ScalarBaseMult
[...]

Vulnerability #3: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.21.13
    Fixed in: crypto/x509@go1.22.11
    Example traces found:
Error:       #2: i18n_test.go:22:24: i18n_test.ExampleInitI18nDomain_embeddedFiles calls gotext.Get, which eventually calls x509.Certificate.Verify
[...]

Vulnerability #4: GO-2024-3107
    Stack exhaustion in Parse in go/build/constraint
  More info: https://pkg.go.dev/vuln/GO-2024-3107
  Standard library
    Found in: go/build/constraint@go1.21.13
    Fixed in: go/build/constraint@go1.22.7
    Example traces found:
Error:       #1: cmd/update-po/main.go:67:31: update.i18nToPot calls pkg.ParsePkgTree, which eventually calls constraint.Parse

Vulnerability #5: GO-2024-3105
    Stack exhaustion in all Parse functions in go/parser
  More info: https://pkg.go.dev/vuln/GO-2024-3105
  Standard library
    Found in: go/parser@go1.21.13
    Fixed in: go/parser@go1.22.7
    Example traces found:
Error:       #1: cmd/update-po/main.go:67:31: update.i18nToPot calls pkg.ParsePkgTree, which eventually calls parser.ParseFile
```