### PR TITLE
Bump Go version to 1.23.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/go-i18n
 
-go 1.23.10
+go 1.23.12
 
 require (
 	github.com/leonelquinteros/gotext v1.5.3-0.20230829162019-37f474cfb069


### PR DESCRIPTION
govulncheck reports the following vulnerability in Go 1.23.10:

```
Vulnerability #1: GO-2025-3956
    Unexpected paths returned from LookPath in os/exec
  More info: https://pkg.go.dev/vuln/GO-2025-3956
  Standard library
    Found in: os/exec@go1.23.10
    Fixed in: os/exec@go1.23.12
    Example traces found:
Error:       #1: cmd/compile-mo/main.go:53:30: compile.generateMos calls exec.Command, which calls exec.LookPath
```