### PR TITLE
ci: Automatically cancel in-progress workflow runs on push

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,6 +1,10 @@
 name: Check if CLA is signed
 on: [pull_request_target]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cla-check:
     name: Check if CLA is signed

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -7,6 +7,10 @@ on:
       - "*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sanity:
     name: Code sanity


### PR DESCRIPTION
If commits are pushed to the same PR in quick succession, the CI jobs run multiple times in parallel, even though older runs are usually not needed. This change saves some resources by automatically cancelling in-progress workflows on new pushes to the same branch.

The implementation is directly from the example of the concurrency keyword: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-concurrency-and-the-default-behavior